### PR TITLE
NOTASK: expand digitalocean_droplets argument_specs

### DIFF
--- a/roles/digitalocean_droplets/meta/argument_specs.yml
+++ b/roles/digitalocean_droplets/meta/argument_specs.yml
@@ -28,6 +28,8 @@ argument_specs:
             choices:
               - present
               - absent
+              - active
+              - inactive
           tags:
             type: list
             elements: str
@@ -35,6 +37,7 @@ argument_specs:
             type: list
             elements: str
           ssh_keys:
+            required: true
             type: list
             elements: str
           ipv6:


### PR DESCRIPTION
add option for droplet(s) to be active/inactive
ensure ssh keys are defined (mandatory) for dropet(s)