### PR TITLE
NOTASK: use digitalocean_tags role for droplet tag management

### DIFF
--- a/roles/digitalocean_droplets/tasks/digitalocean_droplet.yml
+++ b/roles/digitalocean_droplets/tasks/digitalocean_droplet.yml
@@ -27,4 +27,16 @@
     ipv6: "{{ digitalocean_droplet_ipv6 }}"
     monitoring: "{{ digitalocean_droplet_monitoring }}"
     state: "{{ digitalocean_droplet_state }}"
-    tags: "{{ digitalocean_droplet_tags }}"
+
+- name: Ensure digitalocean droplet tags
+  ansible.builtin.include_role:
+    name: damex.digitalocean.digitalocean_tags
+  vars:
+    digitalocean_tags: # noqa: var-naming[no-role-prefix]
+      - name: "{{ digitalocean_droplet_tag.name }}"
+        resource_id: "{{ digitalocean_droplet_id | default(omit) }}"
+        resource_type: droplet
+        state: "{{ digitalocean_droplet_tag.name | default(digitalocean_droplet_state) }}"
+  loop: "{{ digitalocean_droplet_tags }}"
+  loop_control:
+    loop_var: digitalocean_droplet_tag


### PR DESCRIPTION
current droplet ansible module from community digitalocean collection
   does not touch droplet after creation.
that would result in tags never being updated.

here we try to ensure that condition of tags properly by using separate digitalocean_tags role.